### PR TITLE
[#6] 텍스트 길이 감지 및 요약 길이 선택 기능 추가

### DIFF
--- a/pages/demos/generate_summary_and_title_demo.py
+++ b/pages/demos/generate_summary_and_title_demo.py
@@ -1,15 +1,25 @@
 import streamlit as st
+from utils.summaryNewsTest import summary_news      # 요약문 생성
+from utils.generateTitleTest import generate_title  # 제목 생성
 
 
 def run():
     st.title("📝 본문 내용 요약문 및 제목 생성 Demo")
 
-    text = st.text_area("뉴스 본문을 입력하세요:", height=300)
+    text = st.text_area("뉴스 본문을 입력하세요", height=300)
 
     if st.button("Generate"):
         if not text.strip():
             st.warning("텍스트를 입력해주세요.")
         else:
             with st.spinner("생성 중입니다..."):
-                st.success("✅ 생성 완료 !")
-                st.write("To-Do")
+                summary = summary_news(text)
+                title = generate_title(summary)
+                if summary == "error1":
+                    st.warning("언어 감지에 실패하였습니다 (지원 언어: 영어, 한국어)")
+                elif summary == "error2":
+                    st.warning("지원하는 언어가 아닙니다 (지원 언어: 영어, 한국어)")
+                else:
+                    st.success("✅ 생성 완료 !")
+                    st.write(title)
+                    st.write(summary)

--- a/pages/demos/generate_summary_and_title_demo.py
+++ b/pages/demos/generate_summary_and_title_demo.py
@@ -1,25 +1,57 @@
 import streamlit as st
-from utils.summaryNewsTest import summary_news      # 요약문 생성
-from utils.generateTitleTest import generate_title  # 제목 생성
+from utils.summaryNewsTest import summary_news        # 요약문 생성
+from utils.summaryNewsTest import decide_summary_len  # 요약문 길이 설정
+from utils.generateTitleTest import generate_title    # 제목 생성
+from langdetect import detect, LangDetectException    # 언어 감지
 
 
 def run():
-    st.title("📝 본문 내용 요약문 및 제목 생성 Demo")
+    st.title("📝 본문 요약문 및 제목 생성 Demo")
 
+    # TODO: 현재 본문 수동 입력 -> 추후 본문 추출 함수 사용으로 교체 예정
     text = st.text_area("뉴스 본문을 입력하세요", height=300)
+
+    # TODO: 임시 언어 감지 -> 추후 분리된 언어 감지 함수 사용으로 교체 예정
+    try:
+        lang = detect(text)      # 입력된 언어 감지
+    except LangDetectException:  # 언어 감지 실패 (너무 짧은 입력 or 지원언어 아님)
+        lang = None
+
+    st.write("공백 포함 본문 길이(ctrl+enter로 반영)", len(text))
+    if 0 < len(text) < 100:
+        st.warning("입력 길이가 너무 짧습니다 (권장 길이: 100~1000자)")
+
+    length_option = st.radio(
+        "요약문 길이를 선택하세요",
+        ("짧게 (약 100~300자)", "중간 (약 200~400자)", "길게 (약 400~600자)"),
+        horizontal=True
+    )
+
+    if length_option == "짧게 (약 100~300자)":
+        st.session_state['summary_len'] = 'short'
+    elif length_option == "중간 (약 200~400자)":
+        if len(text) < 200:
+            st.warning("입력 길이가 설정 길이보다 짧습니다")
+        st.session_state['summary_len'] = 'medium'
+    else:
+        if len(text) < 400:
+            st.warning("입력 길이가 설정 길이보다 짧습니다")
+        st.session_state['summary_len'] = 'long'
 
     if st.button("Generate"):
         if not text.strip():
             st.warning("텍스트를 입력해주세요.")
         else:
+            summary_min, summary_max = decide_summary_len(lang, st.session_state['summary_len']).values()
             with st.spinner("생성 중입니다..."):
-                summary = summary_news(text)
-                title = generate_title(summary)
+                summary = summary_news(text, lang, summary_min, summary_max)
+                title = generate_title(summary, lang)
                 if summary == "error1":
-                    st.warning("언어 감지에 실패하였습니다 (지원 언어: 영어, 한국어)")
+                    st.error("언어 감지에 실패하였습니다 (지원 언어: 영어, 한국어)")
                 elif summary == "error2":
-                    st.warning("지원하는 언어가 아닙니다 (지원 언어: 영어, 한국어)")
+                    st.error("지원하는 언어가 아닙니다 (지원 언어: 영어, 한국어)")
                 else:
                     st.success("✅ 생성 완료 !")
                     st.write(title)
                     st.write(summary)
+                    st.write("공백 포함 요약문 길이", len(summary))

--- a/pages/samples/generate_title_sample.py
+++ b/pages/samples/generate_title_sample.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from utils.generateTitleTest import generateTitle
+from utils.generateTitleTest import generate_title
 
 
 def run():
@@ -12,6 +12,6 @@ def run():
             st.warning("텍스트를 입력해주세요.")
         else:
             with st.spinner("요약 중입니다..."):
-                title = generateTitle(text)
+                title = generate_title(text)
                 st.success("✅ 제목 생성 완료 !")
                 st.write(title)

--- a/pages/samples/kobart_summary_sample.py
+++ b/pages/samples/kobart_summary_sample.py
@@ -1,5 +1,6 @@
 import streamlit as st
-from utils.summaryNewsTest import summaryNews
+from utils.summaryNewsTest import summary_news
+
 
 def run():
     st.title("📝 KoBART News Summary Demo")
@@ -11,6 +12,6 @@ def run():
             st.warning("텍스트를 입력해주세요.")
         else:
             with st.spinner("요약 중입니다..."):
-                summary = summaryNews(text)
+                summary = summary_news(text)
                 st.success("✅ 요약 결과:")
                 st.write(summary)

--- a/utils/generateTitleTest.py
+++ b/utils/generateTitleTest.py
@@ -1,20 +1,50 @@
+from langdetect import detect                                     # 언어 감지
 import torch
-from transformers import PreTrainedTokenizerFast
-from transformers import BartForConditionalGeneration
+from transformers import PreTrainedTokenizerFast                  # 한국어 제목
+from transformers import BartForConditionalGeneration             # 한국어 제목
+from transformers import T5ForConditionalGeneration, T5Tokenizer  # 영어 제목
 
 
-def generateTitle(text):
+def generate_title(text):
+    if text == "error1" or "error2":  # 요약 실패
+        headline = None
 
-    model = BartForConditionalGeneration.from_pretrained('yebini/kobart-headline-gen')
-    tokenizer = PreTrainedTokenizerFast.from_pretrained('yebini/kobart-headline-gen')
+    lang = detect(text)               # 입력된 언어 감지
 
-    # text =  '서울 중부경찰서는 마약을 투약한 상태로 운전을 하다 교통사고를 내고 도주한 혐의로 40대 남성에 대해 구속영장을 신청했습니다. 이 남성은 지난 5일 오전 6시 15분쯤 서울 중구 광희동의 한 도로에서 마약을 투약한 상태로 고급 외제차를 몰다 신호 대기 중인 차량 2대를 들이받은 뒤 도주한 혐의를 받고 있습니다. 이 남성은 사고 직후 2백 미터가량 달아났다 다시 현장으로 돌아와 경찰에 자수했으며, 마약 간이 시약 검사에선 대마 양성 반응이 나온 걸로 파악됐습니다. 남성이 들이받은 차량에 타고 있던 운전자들은 크게 다치지는 않은 걸로 전해졌으며, 경찰은 남성의 소변과 모발을 국립과학수사연구원에 보내 정밀 감정을 의뢰하고 자세한 경위를 조사하고 있습니다.'
+    if lang == 'en':                  # 감지된 언어 영어
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    inputs = tokenizer(text, return_tensors="pt", padding=True, truncation=True)
-    summary_ids = model.generate(inputs.input_ids, max_length=64, num_beams=5, repetition_penalty=1.2, length_penalty=0.8, early_stopping=True)
+        model = T5ForConditionalGeneration.from_pretrained("Michau/t5-base-en-generate-headline")
+        tokenizer = T5Tokenizer.from_pretrained("Michau/t5-base-en-generate-headline")
+        model = model.to(device)
 
-    title = tokenizer.decode(summary_ids[0], skip_special_tokens=True)
+        article = "headline: " + text
 
-    print("제목:", title)
-    return title
+        encoding = tokenizer.encode_plus(article, return_tensors="pt")
+        input_ids = encoding["input_ids"].to(device)
+        attention_masks = encoding["attention_mask"].to(device)
 
+        headline_ids = model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_masks,
+            max_length=64,
+            num_beams=3,
+            early_stopping=True,
+        )
+        headline = tokenizer.decode(headline_ids[0], skip_special_tokens=True)
+    elif lang == 'ko':                # 감지된 언어 한국어
+        headline_model = BartForConditionalGeneration.from_pretrained('yebini/kobart-headline-gen')
+        headline_tokenizer = PreTrainedTokenizerFast.from_pretrained('yebini/kobart-headline-gen')
+
+        inputs = headline_tokenizer(text, return_tensors="pt", padding=True, truncation=True)
+        headline_ids = headline_model.generate(
+            inputs.input_ids,
+            max_length=64,
+            num_beams=5,
+            repetition_penalty=1.2,
+            length_penalty=0.8,
+            early_stopping=True)
+
+        headline = headline_tokenizer.decode(headline_ids[0], skip_special_tokens=True)
+
+    return headline

--- a/utils/generateTitleTest.py
+++ b/utils/generateTitleTest.py
@@ -1,17 +1,14 @@
-from langdetect import detect                                     # 언어 감지
 import torch
 from transformers import PreTrainedTokenizerFast                  # 한국어 제목
 from transformers import BartForConditionalGeneration             # 한국어 제목
 from transformers import T5ForConditionalGeneration, T5Tokenizer  # 영어 제목
 
 
-def generate_title(text):
+def generate_title(text, lang):
     if text == "error1" or "error2":  # 요약 실패
         headline = None
 
-    lang = detect(text)               # 입력된 언어 감지
-
-    if lang == 'en':                  # 감지된 언어 영어
+    if lang == 'en':                  # 감지된 언어 영어 -> 영어 제목 생성
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
         model = T5ForConditionalGeneration.from_pretrained("Michau/t5-base-en-generate-headline")
@@ -32,7 +29,7 @@ def generate_title(text):
             early_stopping=True,
         )
         headline = tokenizer.decode(headline_ids[0], skip_special_tokens=True)
-    elif lang == 'ko':                # 감지된 언어 한국어
+    elif lang == 'ko':                # 감지된 언어 한국어 -> 한국어 제목 생성
         headline_model = BartForConditionalGeneration.from_pretrained('yebini/kobart-headline-gen')
         headline_tokenizer = PreTrainedTokenizerFast.from_pretrained('yebini/kobart-headline-gen')
 

--- a/utils/summaryNewsTest.py
+++ b/utils/summaryNewsTest.py
@@ -1,22 +1,31 @@
-from transformers import BartForConditionalGeneration, PreTrainedTokenizerFast
+from langdetect import detect, LangDetectException  # 언어 감지 및 예외 처리
+import torch
+from transformers import pipeline  # 영어 기사 요약
+from transformers import BartForConditionalGeneration, PreTrainedTokenizerFast  # 한국어 기사 요약
 
 
-def summaryNews(text):
+def summary_news(text):
+    try:
+        lang = detect(text)      # 입력된 언어 감지
+    except LangDetectException:  # 언어 감지 실패 (너무 짧은 입력 or 지원언어 아님)
+        lang = None
 
-    model = BartForConditionalGeneration.from_pretrained('gogamza/kobart-summarization')
-    tokenizer = PreTrainedTokenizerFast.from_pretrained('gogamza/kobart-summarization')
+    if lang == 'en':             # 감지된 언어 영어
+        summarizer = pipeline("summarization", model="facebook/bart-large-cnn")
+        summary_eng = summarizer(text, max_length=256, min_length=64, do_sample=False)
+        summary = summary_eng[0]['summary_text']
+    elif lang == 'ko':           # 감지된 언어 한국어
+        sum_tokenizer = PreTrainedTokenizerFast.from_pretrained('gogamza/kobart-summarization')
+        sum_model = BartForConditionalGeneration.from_pretrained('gogamza/kobart-summarization')
 
-    inputs = tokenizer([text], max_length=1024, return_tensors="pt", truncation=True)
-    summary_ids = model.generate(
-        inputs['input_ids'],
-        max_length=128,
-        min_length=30,
-        num_beams=4,
-        length_penalty=2.0,
-        early_stopping=True
-    )
-    summary = tokenizer.decode(summary_ids[0], skip_special_tokens=True)
+        raw_input_ids = sum_tokenizer.encode(text)
+        input_ids = [sum_tokenizer.bos_token_id] + raw_input_ids + [sum_tokenizer.eos_token_id]
 
-    print("요약:", summary)
+        summary_ids = sum_model.generate(torch.tensor([input_ids]), max_length=256, min_length=64, num_beams=5)
+        summary = sum_tokenizer.decode(summary_ids.squeeze().tolist(), skip_special_tokens=True)
+    elif not lang:               # 언어 감지에 실패한 경우
+        summary = "error1"
+    else:                        # 감지된 언어가 영어나 한국어가 아닐 경우 (ex. 일본어, 중국어 등)
+        summary = "error2"
+
     return summary
-

--- a/utils/summaryNewsTest.py
+++ b/utils/summaryNewsTest.py
@@ -1,31 +1,55 @@
-from langdetect import detect, LangDetectException  # 언어 감지 및 예외 처리
 import torch
-from transformers import pipeline  # 영어 기사 요약
+from transformers import pipeline    # 영어 기사 요약
 from transformers import BartForConditionalGeneration, PreTrainedTokenizerFast  # 한국어 기사 요약
 
 
-def summary_news(text):
-    try:
-        lang = detect(text)      # 입력된 언어 감지
-    except LangDetectException:  # 언어 감지 실패 (너무 짧은 입력 or 지원언어 아님)
-        lang = None
+def summary_news(text, lang, len_min, len_max):
 
-    if lang == 'en':             # 감지된 언어 영어
+    if lang == 'en':    # 감지된 언어 영어 -> 영어 요약문 생성
         summarizer = pipeline("summarization", model="facebook/bart-large-cnn")
-        summary_eng = summarizer(text, max_length=256, min_length=64, do_sample=False)
+        summary_eng = summarizer(text, max_length=len_max, min_length=len_min, do_sample=False)
         summary = summary_eng[0]['summary_text']
-    elif lang == 'ko':           # 감지된 언어 한국어
+
+    elif lang == 'ko':  # 감지된 언어 한국어 -> 한국어 요약문 생성
         sum_tokenizer = PreTrainedTokenizerFast.from_pretrained('gogamza/kobart-summarization')
         sum_model = BartForConditionalGeneration.from_pretrained('gogamza/kobart-summarization')
 
         raw_input_ids = sum_tokenizer.encode(text)
         input_ids = [sum_tokenizer.bos_token_id] + raw_input_ids + [sum_tokenizer.eos_token_id]
 
-        summary_ids = sum_model.generate(torch.tensor([input_ids]), max_length=256, min_length=64, num_beams=5)
-        summary = sum_tokenizer.decode(summary_ids.squeeze().tolist(), skip_special_tokens=True)
-    elif not lang:               # 언어 감지에 실패한 경우
+        summary_ids = sum_model.generate(
+            torch.tensor([input_ids]),
+            max_length=len_max,
+            min_length=len_min,
+            num_beams=5,
+            repetition_penalty=1.2,
+            no_repeat_ngram_size=3,
+            early_stopping=True
+        )
+        summary_ko = sum_tokenizer.decode(summary_ids.squeeze().tolist(), skip_special_tokens=True)
+        summary = summary_ko.replace('\n', ' ').strip()
+    elif not lang:      # 언어 감지에 실패한 경우
         summary = "error1"
-    else:                        # 감지된 언어가 영어나 한국어가 아닐 경우 (ex. 일본어, 중국어 등)
+    else:               # 감지된 언어가 영어나 한국어가 아닐 경우 (ex. 일본어, 중국어 등)
         summary = "error2"
 
     return summary
+
+
+def decide_summary_len(lang, length_type):
+    length_range_ko = {        # 한국어 요약문 길이 범위 제한
+        'short': {'min': 64, 'max': 160},
+        'medium': {'min': 128, 'max': 256},
+        'long': {'min': 256, 'max': 320},
+    }
+
+    length_range_en = {        # 영어 요약문 길이 범위 제한
+        'short': {'min': 32, 'max': 48},
+        'medium': {'min': 48, 'max': 64},
+        'long': {'min': 64, 'max': 96},
+    }
+
+    if lang == 'ko':
+        return length_range_ko.get(length_type)
+    else:
+        return length_range_en.get(length_type)


### PR DESCRIPTION
## 🌱 SUMMARY 
 - [ ] #6
<br><br>

## ⚠ MORE 
본문 내용에 대한 요약문 및 제목 생성 시의  
본문/요약문 길이 감지 기능과 요약문 길이 선택 기능을 추가 구현하였습니다
이전 PR의 일반 merge로 인해 reset 후 변경사항 반영한 최종 PR 올립니다
확인 후 수정할 사항 말씀해 주시면 감사하겠습니다!!
<br><br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 뉴스 요약 및 제목 생성 데모에 요약 길이(짧게/중간/길게) 선택 기능과 입력 텍스트 길이 경고, 언어 자동 감지 및 오류 메시지 표시 기능이 추가되었습니다.
	- 요약 및 제목 생성이 한국어와 영어 모두 지원됩니다.
- **버그 수정**
	- 입력 언어가 감지되지 않거나 지원되지 않을 때 적절한 오류 메시지가 표시됩니다.
- **리팩터링**
	- 요약 및 제목 생성 함수가 언어별로 통합 및 개선되었으며, 함수명과 파라미터가 일관성 있게 변경되었습니다.
- **문서화**
	- 데모 앱의 UI와 안내 메시지가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->