### PR TITLE
[#17] 기사 분야별 분류 기능 구현

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from pages.samples.kobart_summary_sample import run as kobart_summary
 from pages.samples.generate_title_sample import run as generate_title
 from pages.demos.generate_and_detect_demo import run as generate_and_detect
 from pages.demos.generate_summary_and_title_demo import run as generate_summary_and_title
+from pages.demos.show_saved_articles import run as show_saved_articles
 
 def intro():
     st.title("Welcome to Streamlit! 👋")
@@ -30,7 +31,8 @@ samples = {
 }
 demos = {
     "본문 추출 및 언어 감지 Sample" : generate_and_detect,
-    "본문 내용 요약문 및 제목 생성 Sample" : generate_summary_and_title
+    "본문 내용 요약문 및 제목 생성 Sample" : generate_summary_and_title,
+    "저장된 기사 요약문 보기 Sample" : show_saved_articles
 }
 
 

--- a/pages/demos/generate_summary_and_title_demo.py
+++ b/pages/demos/generate_summary_and_title_demo.py
@@ -66,7 +66,10 @@ def run():
                 summary = summary_news(text, lang, summary_min, summary_max)
                 title = generate_title(summary, lang)
                 topic = detect_topic(summary)
-                save_article(title, summary, topic, lang)
+                try:
+                    save_article(title, summary, topic, lang)
+                except Exception as e:
+                    st.info(f"기사 자동 저장에 실패하였습니다 ({e})")
                 if summary == "error1":
                     st.error("언어 감지에 실패하였습니다 (지원 언어: 영어, 한국어)")
                 elif summary == "error2":

--- a/pages/demos/generate_summary_and_title_demo.py
+++ b/pages/demos/generate_summary_and_title_demo.py
@@ -65,7 +65,7 @@ def run():
             with st.spinner("생성 중입니다..."):
                 summary = summary_news(text, lang, summary_min, summary_max)
                 title = generate_title(summary, lang)
-                topic = detect_topic(summary)
+                topic = detect_topic(text if len(text) <= 512 else summary)
                 try:
                     save_article(title, summary, topic, lang)
                 except Exception as e:

--- a/pages/demos/generate_summary_and_title_demo.py
+++ b/pages/demos/generate_summary_and_title_demo.py
@@ -4,6 +4,8 @@ from utils.summaryNewsTest import decide_summary_len  # 요약문 길이 설정
 from utils.generateTitleTest import generate_title    # 제목 생성
 from utils.extractor import extract_article_text      # 본문 추출
 from utils.language import detect_language            # 언어 감지
+from utils.classify_topic import detect_topic         # 분야 분류
+from utils.article_memory import save_article,show_similar_articles  # 동일 분야 기사 출력
 
 
 def run():
@@ -63,6 +65,8 @@ def run():
             with st.spinner("생성 중입니다..."):
                 summary = summary_news(text, lang, summary_min, summary_max)
                 title = generate_title(summary, lang)
+                topic = detect_topic(summary)
+                save_article(title, summary, topic, lang)
                 if summary == "error1":
                     st.error("언어 감지에 실패하였습니다 (지원 언어: 영어, 한국어)")
                 elif summary == "error2":
@@ -71,4 +75,5 @@ def run():
                     st.success("✅ 생성 완료 !")
                     st.write(f"**{title}**")
                     st.write(summary)
-                    st.write(f"공백 포함 요약문 길이: `{len(summary)}`")
+                    st.write(f"공백 포함 요약문 길이: `{len(summary)}` | 분야: `{topic}`")
+                    show_similar_articles(topic, summary)

--- a/pages/demos/show_saved_articles.py
+++ b/pages/demos/show_saved_articles.py
@@ -40,13 +40,15 @@ def run():
         st.info("조건에 맞는 기사가 없습니다.")
     else:
         st.write(f"총 {len(filtered_articles)}개의 기사 결과")
-        for idx, article in enumerate(filtered_articles):
+        for article in filtered_articles:
             with st.container(border=True):
                 st.write(f"**{article['title']}**")
                 st.write(article['summary'])
                 st.write(f"분야: `{article['topic']}` | 언어: `{article['lang']}`")
 
-                delete_button = st.button(label="삭제", key=idx, use_container_width=True)
+                article_key = f"delete_{hash(article['title'] + article['summary'])}"
+                delete_button = st.button(label="삭제", key=article_key, use_container_width=True)
                 if delete_button:
                     st.session_state.generated_articles.remove(article)
                     st.rerun()
+

--- a/pages/demos/show_saved_articles.py
+++ b/pages/demos/show_saved_articles.py
@@ -1,0 +1,52 @@
+import streamlit as st
+
+
+def run():
+    st.title("저장된 기사 목록")
+    articles = st.session_state.get("generated_articles", [])
+
+    if not articles:
+        st.info("아직 저장된 기사가 없습니다.")
+        return
+
+    st.sidebar.header('세부사항 선택')
+    lang = st.sidebar.selectbox('언어 선택', ['전체', '한국어', '영어'])
+    lang_map = {'전체': None, '한국어': 'ko', '영어': 'en'}
+    selected_lang = lang_map[lang]
+    selected_topic = st.sidebar.selectbox('분야 선택',
+                                 ['전체', 'education', 'human interest', 'society', 'sport', 'crime, law and justice',
+                                  'disaster, accident and emergency incident', 'arts, culture, entertainment and media',
+                                  'politics',
+                                  'economy, business and finance', 'lifestyle and leisure', 'science and technology',
+                                  'health', 'labour', 'religion', 'weather', 'environment', 'conflict, war and peace'])
+
+    def filter_condition(article, lang, topic):
+        # 언어 필터 적용
+        if lang is None or lang == article.get("lang"):
+            lang_filter = True
+        else:
+            lang_filter = False
+        # 분야 필터 적용
+        if topic == "전체" or topic == article.get("topic"):
+            topic_filter = True
+        else:
+            topic_filter = False
+
+        return lang_filter and topic_filter
+
+    filtered_articles = [a for a in articles if filter_condition(a, selected_lang, selected_topic)]
+
+    if not filtered_articles:
+        st.info("조건에 맞는 기사가 없습니다.")
+    else:
+        st.write(f"총 {len(filtered_articles)}개의 기사 결과")
+        for idx, article in enumerate(filtered_articles):
+            with st.container(border=True):
+                st.write(f"**{article['title']}**")
+                st.write(article['summary'])
+                st.write(f"분야: `{article['topic']}` | 언어: `{article['lang']}`")
+
+                delete_button = st.button(label="삭제", key=idx, use_container_width=True)
+                if delete_button:
+                    st.session_state.generated_articles.remove(article)
+                    st.rerun()

--- a/pages/demos/show_saved_articles.py
+++ b/pages/demos/show_saved_articles.py
@@ -1,4 +1,6 @@
 import streamlit as st
+from utils.article_memory import manage_saved_articles
+from utils.classify_topic import get_topic
 
 
 def run():
@@ -13,12 +15,7 @@ def run():
     lang = st.sidebar.selectbox('언어 선택', ['전체', '한국어', '영어'])
     lang_map = {'전체': None, '한국어': 'ko', '영어': 'en'}
     selected_lang = lang_map[lang]
-    selected_topic = st.sidebar.selectbox('분야 선택',
-                                 ['전체', 'education', 'human interest', 'society', 'sport', 'crime, law and justice',
-                                  'disaster, accident and emergency incident', 'arts, culture, entertainment and media',
-                                  'politics',
-                                  'economy, business and finance', 'lifestyle and leisure', 'science and technology',
-                                  'health', 'labour', 'religion', 'weather', 'environment', 'conflict, war and peace'])
+    selected_topic = st.sidebar.selectbox('분야 선택', ["전체"]+get_topic())
 
     def filter_condition(article, lang, topic):
         # 언어 필터 적용
@@ -41,14 +38,4 @@ def run():
     else:
         st.write(f"총 {len(filtered_articles)}개의 기사 결과")
         for article in filtered_articles:
-            with st.container(border=True):
-                st.write(f"**{article['title']}**")
-                st.write(article['summary'])
-                st.write(f"분야: `{article['topic']}` | 언어: `{article['lang']}`")
-
-                article_key = f"delete_{hash(article['title'] + article['summary'])}"
-                delete_button = st.button(label="삭제", key=article_key, use_container_width=True)
-                if delete_button:
-                    st.session_state.generated_articles.remove(article)
-                    st.rerun()
-
+            manage_saved_articles(article)

--- a/utils/article_memory.py
+++ b/utils/article_memory.py
@@ -1,0 +1,34 @@
+import streamlit as st
+
+
+# 생성된 요약 결과들 세션에 저장
+def save_article(title, summary, topic, lang):
+    if title is None:  # 정상적으로 생성된 요약문만 저장되도록
+        return
+
+    if "generated_articles" not in st.session_state:
+        st.session_state.generated_articles = []
+
+    st.session_state.generated_articles.append({
+        "title": title,
+        "summary": summary,
+        "topic": topic,
+        "lang": lang
+    })
+
+
+def show_similar_articles(current_topic, current_summary):
+    if "generated_articles" not in st.session_state:
+        return
+
+    similar_articles = [
+        article for article in st.session_state.generated_articles
+        if article["topic"] == current_topic and article["summary"] != current_summary
+    ]
+
+    if similar_articles:
+        st.write("---")
+        st.subheader(f"같은 분야({current_topic})의 기사들")
+        for article in similar_articles:
+            with st.expander(f"**{article['title']}**"):
+                st.write(article["summary"])

--- a/utils/article_memory.py
+++ b/utils/article_memory.py
@@ -9,6 +9,11 @@ def save_article(title: str, summary: str, topic:str, lang:str) -> None:
     if "generated_articles" not in st.session_state:
         st.session_state.generated_articles = []
 
+    # 기사 중복 저장 방지
+    for article in st.session_state.generated_articles:
+        if article["title"] == title.strip() and article["summary"] == summary.strip():
+            return
+
     st.session_state.generated_articles.append({
         "title": title.strip(),
         "summary": summary.strip(),

--- a/utils/article_memory.py
+++ b/utils/article_memory.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from utils.classify_topic import get_topic
 
 
 # 생성된 요약 결과들 세션에 저장
@@ -37,3 +38,32 @@ def show_similar_articles(current_topic, current_summary):
         for article in similar_articles:
             with st.expander(f"**{article['title']}**"):
                 st.write(article["summary"])
+
+
+def manage_saved_articles(article):
+    article_key = f"{hash(article['title'] + article['summary'])}"
+
+    with st.container(border=True):
+        st.write(f"**{article['title']}**")
+        st.write(article["summary"])
+        st.write(f"분야: `{article['topic']}` | 언어: `{article['lang']}`")
+
+        col1, col2 = st.columns(2)
+
+        with col1:
+            if st.button("수정", key=f"edit_{article_key}", use_container_width=True):
+                st.session_state[f"edited_{article_key}"] = True
+
+        with col2:
+            if st.button("삭제", key=f"delete_{article_key}", use_container_width=True):
+                st.session_state.generated_articles.remove(article)
+                st.rerun()
+
+        if st.session_state.get(f"edited_{article_key}", False):
+            st.write("---")
+            modified_topic = st.selectbox("새로운 분야를 선택하세요", get_topic(), index=get_topic().index(article["topic"]))
+
+            if st.button("저장", use_container_width=True):
+                article["topic"] = modified_topic
+                st.session_state[f"edited_{article_key}"] = False
+                st.rerun()

--- a/utils/article_memory.py
+++ b/utils/article_memory.py
@@ -2,7 +2,7 @@ import streamlit as st
 
 
 # 생성된 요약 결과들 세션에 저장
-def save_article(title, summary, topic, lang):
+def save_article(title: str, summary: str, topic:str, lang:str) -> None:
     if title is None:  # 정상적으로 생성된 요약문만 저장되도록
         return
 
@@ -10,8 +10,8 @@ def save_article(title, summary, topic, lang):
         st.session_state.generated_articles = []
 
     st.session_state.generated_articles.append({
-        "title": title,
-        "summary": summary,
+        "title": title.strip(),
+        "summary": summary.strip(),
         "topic": topic,
         "lang": lang
     })

--- a/utils/classify_topic.py
+++ b/utils/classify_topic.py
@@ -18,3 +18,12 @@ def detect_topic(text):
     classifier = load_classifier()
     result = classifier(text)[0]["label"]
     return result
+
+
+def get_topic():
+    topic = ['education', 'human interest', 'society', 'sport', 'crime, law and justice',
+             'disaster, accident and emergency incident', 'arts, culture, entertainment and media',
+             'politics', 'economy, business and finance', 'lifestyle and leisure', 'science and technology',
+             'health', 'labour', 'religion', 'weather', 'environment', 'conflict, war and peace']
+
+    return topic

--- a/utils/classify_topic.py
+++ b/utils/classify_topic.py
@@ -1,9 +1,20 @@
 from transformers import pipeline
+import streamlit as st
 
-classifier = pipeline("text-classification", model="classla/multilingual-IPTC-news-topic-classifier",
-                      device=-1, max_length=512, truncation=True)
+
+@st.cache_resource
+def load_classifier():
+    try:
+        classifier = pipeline("text-classification",
+                              model="classla/multilingual-IPTC-news-topic-classifier",
+                              device=-1, max_length=512, truncation=True)
+    except Exception as e:
+        raise RuntimeError(f"분류 모델 로딩에 실패했습니다 : {e}")
+
+    return classifier
 
 
 def detect_topic(text):
+    classifier = load_classifier()
     result = classifier(text)[0]["label"]
     return result

--- a/utils/classify_topic.py
+++ b/utils/classify_topic.py
@@ -1,0 +1,9 @@
+from transformers import pipeline
+
+classifier = pipeline("text-classification", model="classla/multilingual-IPTC-news-topic-classifier",
+                      device=-1, max_length=512, truncation=True)
+
+
+def detect_topic(text):
+    result = classifier(text)[0]["label"]
+    return result


### PR DESCRIPTION
## 🌱 SUMMARY  
- [ ] #17 
<br><br>

## ⚠️ MORE 
한국어/영어 기사 요약문에 대한 분야 분류 기능을 추가했습니다!
또한 세션 상태 저장을 활용하여 동일 분야 기사 출력 기능과 저장된 요약문들을 보여주는 페이지를 추가했으며,
추가된 페이지에는 요약문에 대한 언어/분야 조건별 필터링 적용이 가능합니다
참고로 필터링에 사용되는 분야 목록은 분류 모델에서 사전에 정의한 라벨 목록을 그대로 반영한 것입니다!
확인 후 편하게 피드백 주시면 감사하겠습니다...

++
코드리뷰봇이 제안한 수정사항 중 일부를 반영했습니다
추가로 테스트 중 분야가 잘못 분류되는 경우를 발견하여 저장된 요약문의 분야 수정 기능을 추가했습니다!
<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 요약 및 제목 생성 데모에 주제 분류, 기사 저장, 유사 기사 추천 기능이 추가되었습니다.
    - 저장된 기사 요약문을 확인하고, 언어 및 주제별로 필터링하거나 개별 기사를 편집 및 삭제할 수 있는 페이지가 추가되었습니다.
- **기타**
    - 기사 요약문을 세션에 저장하고, 주제별 유사 기사를 표시하는 기능이 도입되었습니다.
    - 텍스트의 주제를 자동으로 분류하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->